### PR TITLE
Fixed link to grades.csv

### DIFF
--- a/03-multiple-regression.Rmd
+++ b/03-multiple-regression.Rmd
@@ -24,7 +24,7 @@ Let's look at some (made up, but realistic) data to see how we can use multiple 
 
 ### Data import and visualization
 
-Let's load in the data [grades.csv](data/grades.csv){target="_download"} and have a look.
+Let's load in the data [grades.csv](https://raw.githubusercontent.com/PsyTeachR/stat-models-v1/master/data/grades.csv){target="_download"} and have a look.
 
 ```{r load-data, message=FALSE}
 library("corrr") # correlation matrices


### PR DESCRIPTION
The link to **grades.csv** in section 3.1.1 (https://psyteachr.github.io/stat-models-v1/multiple-regression.html) leads to 404 page not found. Changed the link to its raw view to fix. Not sure if this is the best way to link to **grades.csv** or to any of the other data files in **data/**.